### PR TITLE
Make sure button action fires asynchronously

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,6 +1,6 @@
 /**
  * Background script.
- * 
+ *
  * This only does anything when the bookmarking button is clicked
  */
 chromeOrBrowser().browserAction.onClicked.addListener(function(tab) {
@@ -16,13 +16,14 @@ chromeOrBrowser().browserAction.onClicked.addListener(function(tab) {
         }
 
         chromeOrBrowser().tabs.executeScript(null, {
-            file: "/js/bookmarker.js"
-        });
-   
-        chromeOrBrowser().tabs.query({active: true, currentWindow: true}, function(tabs) {
-            chromeOrBrowser().tabs.sendMessage(tabs[0].id, {tenantCode: tenantCode});
+            file: "/js/bookmarker.js",
+            runAt: 'document_end'
         });
 
-        return;   
+        chromeOrBrowser().tabs.query({active: true, currentWindow: true}, function(tabs) {
+            chromeOrBrowser().tabs.sendMessage(tabs[0].id, {tenantCode: tenantCode});
+            return true;
+        });
+        return;
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-reading-lists-bookmarker",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A browser extension to bookmark resources to Talis Aspire Reading Lists",
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
We have had reported problems with the extension requiring multiple clicks on certain pages.  The behavior was intermittent, so isolating the cause was extremely difficult.

We _think_ it has to do with the extension firing before the DOM finishes loading completely on the page and lots of digging later led me to:
https://stackoverflow.com/questions/18592705/best-way-to-wait-for-a-chrome-tabs-query-callback

This forces the extension to send the message to bookmark.js asynchronously - it _seems_ like the problem might have been that the extension was trying to fire but was getting lost in the DOM rendering.