### PR TITLE
ENT-1377 double click bookmark problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.idea
 bower_components/
 dist/
 node_modules/

--- a/js/background.js
+++ b/js/background.js
@@ -3,28 +3,21 @@
  *
  * This only does anything when the bookmarking button is clicked
  */
-var executedScript = false;
 chromeOrBrowser().browserAction.onClicked.addListener(function(currentTab) {
     // If no institution has been set, go to the options page to set one
     getActiveTenant(function (tenantCode) {
         if (!tenantCode) {
-            if (window.confirm(chromeOrBrowser().i18n.getMessage('noTenantAlert'))) {
-                // browser.runtime.openOptionsPage() not supported by ms-edge, so here's a workaround
-                chromeOrBrowser().tabs.create({
-                    url: chromeOrBrowser().extension.getURL("options.html")
-                  });
-            }
-        }
-        if (!executedScript) {
+            // browser.runtime.openOptionsPage() not supported by ms-edge, so here's a workaround
+            chromeOrBrowser().tabs.create({
+                url: chromeOrBrowser().extension.getURL("options.html")
+            });
+        } else {
             chromeOrBrowser().tabs.executeScript(null, {
                 file: "/js/bookmarker.js",
                 runAt: 'document_end'
             }, function () {
-                executedScript = true;
                 chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
             });
-        } else {
-            chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
         }
     });
 });

--- a/js/background.js
+++ b/js/background.js
@@ -15,11 +15,7 @@ chromeOrBrowser().browserAction.onClicked.addListener(function(currentTab) {
             }
         }
 
-        chromeOrBrowser().tabs.executeScript(null, {
-            file: "/js/bookmarker.js",
-            runAt: 'document_end'
-        }, function () {
-            chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
-        });
+        console.log(new Date().getTime() + ': background.js: already have bookmarker.js SENDING');
+        chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
     });
 });

--- a/js/background.js
+++ b/js/background.js
@@ -3,7 +3,7 @@
  *
  * This only does anything when the bookmarking button is clicked
  */
-chromeOrBrowser().browserAction.onClicked.addListener(function(tab) {
+chromeOrBrowser().browserAction.onClicked.addListener(function(currentTab) {
     // If no institution has been set, go to the options page to set one
     getActiveTenant(function (tenantCode) {
         if (!tenantCode) {
@@ -18,12 +18,8 @@ chromeOrBrowser().browserAction.onClicked.addListener(function(tab) {
         chromeOrBrowser().tabs.executeScript(null, {
             file: "/js/bookmarker.js",
             runAt: 'document_end'
+        }, function () {
+            chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
         });
-
-        chromeOrBrowser().tabs.query({active: true, currentWindow: true}, function(tabs) {
-            chromeOrBrowser().tabs.sendMessage(tabs[0].id, {tenantCode: tenantCode});
-            return true;
-        });
-        return true;
     });
 });

--- a/js/background.js
+++ b/js/background.js
@@ -3,6 +3,7 @@
  *
  * This only does anything when the bookmarking button is clicked
  */
+var executedScript = false;
 chromeOrBrowser().browserAction.onClicked.addListener(function(currentTab) {
     // If no institution has been set, go to the options page to set one
     getActiveTenant(function (tenantCode) {
@@ -14,8 +15,16 @@ chromeOrBrowser().browserAction.onClicked.addListener(function(currentTab) {
                   });
             }
         }
-
-        console.log(new Date().getTime() + ': background.js: already have bookmarker.js SENDING');
-        chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
+        if (!executedScript) {
+            chromeOrBrowser().tabs.executeScript(null, {
+                file: "/js/bookmarker.js",
+                runAt: 'document_end'
+            }, function () {
+                executedScript = true;
+                chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
+            });
+        } else {
+            chromeOrBrowser().tabs.sendMessage(currentTab.id, {tenantCode: tenantCode});
+        }
     });
 });

--- a/js/bookmarker.js
+++ b/js/bookmarker.js
@@ -2,29 +2,28 @@
  * Content script to inject the dynamic bookmarking JS directly into the page.
  */
 
-(function() {
-  function chromeOrBrowser() {
-    return this.browser || chrome;
-  }
-  /**
-   * Injected into page to redirect to the dynamic page parser
-   *
-   * @param {String} tenantCode
-   */
-  function bookmarkPage(tenantCode, cb) {
-    var bookmarker = document.createElement('script');
-    bookmarker.setAttribute(
-      'src',
-      'https://bookmarking.talis.com/' + tenantCode + '/parser?bookmarkButtonVersion=1&uri=' +
-        encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
-        encodeURIComponent(document.title) + '&hasJquery=no'
-      );
+function chromeOrBrowser() {
+  return this.browser || chrome;
+}
+console.log(new Date().getTime() + ': bookmarker.js');
+/**
+ * Injected into page to redirect to the dynamic page parser
+ *
+ * @param {String} tenantCode
+ */
+function bookmarkPage(tenantCode) {
+  var bookmarker = document.createElement('script');
+  bookmarker.setAttribute(
+    'src',
+    'https://bookmarking.talis.com/' + tenantCode + '/parser?bookmarkButtonVersion=1&uri=' +
+      encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
+      encodeURIComponent(document.title) + '&hasJquery=no'
+    );
+  if (document.body) {
     document.body.appendChild(bookmarker);
-    cb();
   }
-  chromeOrBrowser().runtime.onMessage.addListener(function(message, sender, sendResponse) {
-    bookmarkPage(message.tenantCode, function () {
-      sendResponse({status: 'ok'});
-    });
-  });
-})();
+}
+chromeOrBrowser().runtime.onMessage.addListener(function(message) {
+  console.log(new Date().getTime() + ': bookmarker.js: onMessage callback');
+  bookmarkPage(message.tenantCode);
+});

--- a/js/bookmarker.js
+++ b/js/bookmarker.js
@@ -5,13 +5,16 @@
 function chromeOrBrowser() {
   return this.browser || chrome;
 }
-console.log(new Date().getTime() + ': bookmarker.js');
 /**
  * Injected into page to redirect to the dynamic page parser
  *
  * @param {String} tenantCode
  */
 function bookmarkPage(tenantCode) {
+  if (document.getElementById('bookmarkingScript')) {
+    document.getElementById('bookmarkingScript').remove();
+  }
+
   var bookmarker = document.createElement('script');
   bookmarker.setAttribute(
     'src',
@@ -19,11 +22,12 @@ function bookmarkPage(tenantCode) {
       encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
       encodeURIComponent(document.title) + '&hasJquery=no'
     );
+  bookmarker.setAttribute('id', 'bookmarkingScript');
+
   if (document.body) {
     document.body.appendChild(bookmarker);
   }
 }
 chromeOrBrowser().runtime.onMessage.addListener(function(message) {
-  console.log(new Date().getTime() + ': bookmarker.js: onMessage callback');
   bookmarkPage(message.tenantCode);
 });

--- a/js/bookmarker.js
+++ b/js/bookmarker.js
@@ -12,8 +12,10 @@
    * @param {String} tenantCode
    */
   function bookmarkPage(tenantCode) {
-    if (document.getElementById('bookmarkingScript')) {
-      document.getElementById('bookmarkingScript').remove();
+    var bookmarkingScriptId = '__talis_' + tenantCode + '_bookmarkingScript';
+
+    if (document.getElementById(bookmarkingScriptId)) {
+      document.getElementById(bookmarkingScriptId).remove();
     }
 
     var bookmarker = document.createElement('script');
@@ -23,7 +25,7 @@
         encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
         encodeURIComponent(document.title) + '&hasJquery=no'
     );
-    bookmarker.setAttribute('id', 'bookmarkingScript');
+    bookmarker.setAttribute('id', bookmarkingScriptId);
 
     if (document.body) {
       document.body.appendChild(bookmarker);

--- a/js/bookmarker.js
+++ b/js/bookmarker.js
@@ -1,33 +1,36 @@
 /*
  * Content script to inject the dynamic bookmarking JS directly into the page.
  */
-
-function chromeOrBrowser() {
-  return this.browser || chrome;
-}
-/**
- * Injected into page to redirect to the dynamic page parser
- *
- * @param {String} tenantCode
- */
-function bookmarkPage(tenantCode) {
-  if (document.getElementById('bookmarkingScript')) {
-    document.getElementById('bookmarkingScript').remove();
+(function() {
+  function chromeOrBrowser() {
+    return this.browser || chrome;
   }
 
-  var bookmarker = document.createElement('script');
-  bookmarker.setAttribute(
-    'src',
-    'https://bookmarking.talis.com/' + tenantCode + '/parser?bookmarkButtonVersion=1&uri=' +
-      encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
-      encodeURIComponent(document.title) + '&hasJquery=no'
+  /**
+   * Injected into page to redirect to the dynamic page parser
+   *
+   * @param {String} tenantCode
+   */
+  function bookmarkPage(tenantCode) {
+    if (document.getElementById('bookmarkingScript')) {
+      document.getElementById('bookmarkingScript').remove();
+    }
+
+    var bookmarker = document.createElement('script');
+    bookmarker.setAttribute(
+        'src',
+        'https://bookmarking.talis.com/' + tenantCode + '/parser?bookmarkButtonVersion=1&uri=' +
+        encodeURIComponent(encodeURI(window.location.href)) + '&bookmarkVersion=1&title=' +
+        encodeURIComponent(document.title) + '&hasJquery=no'
     );
-  bookmarker.setAttribute('id', 'bookmarkingScript');
+    bookmarker.setAttribute('id', 'bookmarkingScript');
 
-  if (document.body) {
-    document.body.appendChild(bookmarker);
+    if (document.body) {
+      document.body.appendChild(bookmarker);
+    }
   }
-}
-chromeOrBrowser().runtime.onMessage.addListener(function(message) {
-  bookmarkPage(message.tenantCode);
-});
+
+  chromeOrBrowser().runtime.onMessage.addListener(function (message) {
+    bookmarkPage(message.tenantCode);
+  });
+})();

--- a/js/options.js
+++ b/js/options.js
@@ -31,6 +31,9 @@ $(function() {
 
 function loadTenantList() {
     getActiveTenant(function(activeTenant) {
+        if (!activeTenant) {
+            $('#optionsHelp').html('<div class="alert alert-warning">' + chromeOrBrowser().i18n.getMessage('noTenantAlert') + '</div>');
+        }
         $('#tenantCode').val(activeTenant);
         getTenants(function(tenants) {
             var matched = false;

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "persistent": false
     },
     "permissions": [
-        "activeTab", "storage", "https://talis-public.talis.com/*"
+        "activeTab", "storage", "https://talis-public.talis.com/*", "*://*/*"
     ],
     "options_ui": {
         "page": "options.html",
@@ -33,6 +33,14 @@
             "40": "images/icon40.png"
           }
     },
+    "content_scripts": [
+        {
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": ["js/bookmarker.js"]
+        }
+    ],
     "default_locale": "en",
     "manifest_version": 2
 }

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "persistent": false
     },
     "permissions": [
-        "activeTab", "storage", "https://talis-public.talis.com/*", "*://*/*"
+        "activeTab", "storage", "https://talis-public.talis.com/*"
     ],
     "options_ui": {
         "page": "options.html",
@@ -33,14 +33,6 @@
             "40": "images/icon40.png"
           }
     },
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": ["js/bookmarker.js"]
-        }
-    ],
     "default_locale": "en",
     "manifest_version": 2
 }

--- a/options.html
+++ b/options.html
@@ -16,6 +16,7 @@
         <div class="row" id="status">
 
         </div>
+        <div class="row" id="optionsHelp"></div>
         <div class="row">
             <div class="col-xs-2">
                 <span data-message="optionsInstitutionLabel">Institution:</span><br>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-reading-lists-bookmarker",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A browser extension to bookmark resources to Talis Aspire Reading Lists",
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
We've had reports of the bookmark extension not working properly and users having to double click to get it to work.

I did manage to replicate this on master for a while, I put some console.logs in and i could see the background.js script send the message, but bookmarker.js not receive it. 

It's since started working again but i think the problem was that we were calling the `executeScript` but not waiting for it to finish before firing off a message to it - so it was never in a position to receive the message. Once you've already clicked on the button once, the script is then injected, so it can receive the message.

Something else I found was that because we're executing the script every time you click on it, if something goes wrong and you click it again, you end up executing the script twice and the message is then received twice. Do it again and you get 3 messages, etc, etc.

I've made a couple of changes here:
* Use a content_script to inject the bookmarker.js script once into the page - we then don't have to worry about the timings of the `executeScript`.
* We already have the current tab that the user has clicked on, so got rid of the `tabs.query` bit to then send `tabs[0].id` in the call to `tabs.sendMessage`.

I'm not sure of the historical context around this - maybe we had to use the execute script because of other browser limitations - i've only tested this in Chrome so far. @rsinger might have some answers here.

I've left the console.logs in for now so we can debug it - these will all need to go before this is merged.

Since i've made these changes, I've not been able to get it to not receive a message, which is what i think the problem has been.

Another way of approaching this would be to use a callback on `executeScript` and only send the message inside there. I believe this will fix the double click, but won't stop multiple messages (its multiple scripts really rather than messages) happening.

