### PR TITLE
Convert the active tenant in local storage from a string to an object transparently if the user has previously saved their institution 

### DIFF
--- a/js/bookmarker.js
+++ b/js/bookmarker.js
@@ -19,6 +19,7 @@
     }
 
     var bookmarker = document.createElement('script');
+
     var bookmarkingEndpoint = (
       tenant.region === 'CA' ?
       'https://bookmarking.ca.talis.com' :

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-reading-lists-bookmarker",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A browser extension to bookmark resources to Talis Aspire Reading Lists",
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
The 0.3.7 release saves the active tenant in local storage as an object. However, in previous releases this was a simple string that contained the tenant shortcode.  This P/R modifies the behaviour of the extension so that it does the following

- checks to see if active tenant has a region property
- if it does, then it is simply returned
- if it does not, then 
  - we get the complete list of tenants from the customers.json endpoint
  - we find the tenant (object) in that list that matches the activeTenant short code
  - we overwrite the activeTenant in local storage with the object, and return it

This transparently migrates the string activeTenant to the object we need.

### Tested

- [x] Chrome
- [x] Firefox
- [x] MS Edge