### PR TITLE
Selecting Other now asks you to specify the region

### DIFF
--- a/_locales/cy/messages.json
+++ b/_locales/cy/messages.json
@@ -6,7 +6,7 @@
     "description": {
         "message": "Talis Aspire Rhestrau Darllen Offeryn Nod Tudalen",
         "description": "Extension description"
-    },    
+    },
     "browserActionTitle": {
         "message": "Ychwanegu Llyfrnod at Rhestr Ddarllen",
         "description": "Message when hovering over extension button"
@@ -30,6 +30,18 @@
     "optionsOtherOptionLabel": {
         "message": "Arall",
         "description": "Manually specify tenant short code option"
+    },
+    "optionsRegionLabel": {
+        "message": "Rhanbarth",
+        "description": "Manually specify region for the given tenant short code optionu"
+    },
+    "optionsRegionEUAPACLabel": {
+        "message": "EU / APAC",
+        "description": "This option sets the region to EU / APAC"
+    },
+    "optionsRegionCALabel": {
+        "message": "CA",
+        "description": "This option sets the region to CA"
     },
     "optionsShortCodeLabel": {
         "message": "Cod byr:",

--- a/_locales/cy/messages.json
+++ b/_locales/cy/messages.json
@@ -36,11 +36,11 @@
         "description": "Manually specify region for the given tenant short code option"
     },
     "optionsRegionEUAPACLabel": {
-        "message": "EU / APAC",
+        "message": "Ewrop / Asia Môr Tawel",
         "description": "This option sets the region to EU / APAC"
     },
     "optionsRegionCALabel": {
-        "message": "CA",
+        "message": "Canada",
         "description": "This option sets the region to CA"
     },
     "optionsShortCodeLabel": {

--- a/_locales/cy/messages.json
+++ b/_locales/cy/messages.json
@@ -58,5 +58,13 @@
     "noTenantAlert": {
         "message": "Nodwch sefydliad mewn lleoliadau ymestyn",
         "description": "Alert presented if no institution has been set"
+    },
+    "noTenantShortCodeAlert": {
+        "message": "Wrth ddewis Arall rhaid i chi nodi cod byr tenant",
+        "description": "Alert presented if Other institution is selected but no short code is provided"
+    },
+    "noTenantRegionAlert": {
+        "message": "Wrth ddewis Arall rhaid i chi nodi rhanbarth",
+        "description": "Alert presented if Other institution is selected but no region is provided"
     }
 }

--- a/_locales/cy/messages.json
+++ b/_locales/cy/messages.json
@@ -33,7 +33,7 @@
     },
     "optionsRegionLabel": {
         "message": "Rhanbarth",
-        "description": "Manually specify region for the given tenant short code optionu"
+        "description": "Manually specify region for the given tenant short code option"
     },
     "optionsRegionEUAPACLabel": {
         "message": "EU / APAC",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6,7 +6,7 @@
     "description": {
         "message": "Talis Aspire Reading Lists Bookmarking",
         "description": "Extension description"
-    },    
+    },
     "browserActionTitle": {
         "message": "Bookmark to Talis Aspire Reading Lists",
         "description": "Message when hovering over extension button"
@@ -30,6 +30,18 @@
     "optionsOtherOptionLabel": {
         "message": "Other",
         "description": "Manually specify tenant short code option"
+    },
+    "optionsRegionLabel": {
+        "message": "Region",
+        "description": "Manually specify region for the given tenant short code option"
+    },
+    "optionsRegionEUAPACLabel": {
+        "message": "EU / APAC",
+        "description": "This option sets the region to EU / APAC"
+    },
+    "optionsRegionCALabel": {
+        "message": "CA",
+        "description": "This option sets the region to CA"
     },
     "optionsShortCodeLabel": {
         "message": "Short code:",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -58,5 +58,13 @@
     "noTenantAlert": {
         "message": "Please specify an institution in extension settings",
         "description": "Alert presented if no institution has been set"
+    },
+    "noTenantShortCodeAlert": {
+        "message": "When selecting Other you must specify a tenant short code",
+        "description": "Alert presented if Other institution is selected but no short code is provided"
+    },
+    "noTenantRegionAlert": {
+        "message": "When selecting Other you must specify a region",
+        "description": "Alert presented if Other institution is selected but no region is provided"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -36,11 +36,11 @@
         "description": "Manually specify region for the given tenant short code option"
     },
     "optionsRegionEUAPACLabel": {
-        "message": "EU / APAC",
-        "description": "This option sets the region to EU / APAC"
+        "message": "Europe / Asia Pacific",
+        "description": "This option sets the region to EU/APAC"
     },
     "optionsRegionCALabel": {
-        "message": "CA",
+        "message": "Canada",
         "description": "This option sets the region to CA"
     },
     "optionsShortCodeLabel": {

--- a/js/options.js
+++ b/js/options.js
@@ -12,6 +12,17 @@ $(function() {
         if ($('#specifyTenant:selected').length > 0) {
             var otherTenantCode = $('#tenantCode').val();
             var otherTenantRegion = $('#tenantRegion').val();
+
+            if (!otherTenantCode.trim()) {
+                $('#optionsHelp').html('<div class="alert alert-danger">' + chromeOrBrowser().i18n.getMessage('noTenantShortCodeAlert') + '</div>');
+                return;
+            }
+
+            if (!otherTenantRegion.trim()) {
+                $('#optionsHelp').html('<div class="alert alert-danger">' + chromeOrBrowser().i18n.getMessage('noTenantRegionAlert') + '</div>');
+                return;
+            }
+
             saveActiveTenantAndUpdateStatus(
                 buildTenant(otherTenantCode, otherTenantRegion)
             );

--- a/js/options.js
+++ b/js/options.js
@@ -9,20 +9,21 @@ $(function() {
         }
     });
     $('#save').on('click', function() {
-        getTenants(function(tenants) {
-            for (var tenantCode in tenants) {
-                if (tenantCode === $('#tenantCode').val()) {
-                  saveActiveTenant(tenants[tenantCode], function() {
-                    // Update status to let user know options were saved.
-                    $('#status').html('<div class="alert alert-success">' + chromeOrBrowser().i18n.getMessage('optionsSettingsSaved') + '</div>');
-                    $('#optionsHelp').addClass('hidden');
-                    setTimeout(function() {
-                      $('#status').textContent = '';
-                    }, 750);
-                  });
+        if ($('#specifyTenant:selected').length > 0) {
+            var otherTenantCode = $('#tenantCode').val();
+            var otherTenantRegion = $('#tenantRegion').val();
+            saveActiveTenantAndUpdateStatus(
+                buildTenant(otherTenantCode, otherTenantRegion)
+            );
+        } else {
+            getTenants(function(tenants) {
+                for (var tenantCode in tenants) {
+                    if (tenantCode === $('#tenantCode').val()) {
+                        saveActiveTenantAndUpdateStatus(tenants[tenantCode]);
+                    }
                 }
-            }
-        });
+            });
+        }
     });
 
     var objects = document.getElementsByTagName('*'), i;
@@ -33,6 +34,17 @@ $(function() {
     }
     loadTenantList();
 });
+
+function saveActiveTenantAndUpdateStatus(tenant) {
+    saveActiveTenant(tenant, function() {
+        // Update status to let user know options were saved.
+        $('#status').html('<div class="alert alert-success">' + chromeOrBrowser().i18n.getMessage('optionsSettingsSaved') + '</div>');
+        $('#optionsHelp').addClass('hidden');
+        setTimeout(function() {
+            $('#status').textContent = '';
+        }, 750);
+    });
+}
 
 function loadTenantList() {
     getActiveTenant(function(activeTenant) {

--- a/js/tenants.js
+++ b/js/tenants.js
@@ -158,3 +158,21 @@ function getTenantList(cb) {
         cb(tenants);
     });
 }
+
+/**
+ * Simple helper function that returns a tenant object based on a specified
+ * code and region
+ *
+ * @param {string} tenantCode - the tenant short code
+ * @param {string} tenantRegion - the region for this tenancy
+ */
+function buildTenant(tenantCode, tenantRegion) {
+  return {
+    "name" : tenantCode,
+    "code" : tenantCode,
+    "apps" : {
+      "rl" : true
+    },
+    "region" : tenantRegion
+  }
+}

--- a/options.html
+++ b/options.html
@@ -31,13 +31,24 @@
                 <button id="save" data-message="optionsSave">Save</button>
             </div>
         </div>
-        <div class="row hidden" id="manualEntry">
-            <div class="col-xs-2" data-message="optionsShortCodeLabel">Short code:</div>
-            <div class="col-xs-8">
-                <input type="text" id="tenantCode" />
+        <div class="hidden" id="manualEntry">
+            <div class="row">
+                <div class="col-xs-2" data-message="optionsShortCodeLabel">Short code:</div>
+                <div class="col-xs-2">
+                    <input type="text" id="tenantCode" />
+                </div>
             </div>
+            <div class="row">
+                <div class="col-xs-2" data-message="optionsRegionLabel">Region:</div>
+                <div class="col-xs-2">
+                    <select id="tenantRegion">
+                        <option value="" data-message="optionsChooseOneOptionLabel">Choose one</option>
+                        <option id="EUAPAC" value="EUAPAC" data-message="optionsRegionEUAPACLabel">EU / APAC</option>
+                        <option id="CA" value="CA" data-message="optionsRegionCALabel">Canada</option>
+                    </select>
+                </div>
+                </div>
         </div>
-
     </div>
 </body>
 </html>


### PR DESCRIPTION
- When we updated the extension to use an object to represent the
  selected tenant this stopped users being able to select "Other" and
  specify the tenant short code.
- This change asks the user to also specify a Region and then generates
  a tenant object which is set correctly.
- I've added some simple validation checks specifically around inputting the shortcode and selecting region. Important to note that shortcode never had any validation on it previously. 
- also ensured that I have updated messages.json for both locales to cover the new labels and options that I've included.

### Screenshots


#### Firefox

##### Error No short code

![image](https://user-images.githubusercontent.com/1135464/93569590-a7d7e080-f989-11ea-83a9-fe515dd1b834.png)

##### Error No Region

![image](https://user-images.githubusercontent.com/1135464/93569618-b2927580-f989-11ea-88a4-0ba43803c26c.png)

##### Success 

![image](https://user-images.githubusercontent.com/1135464/93570103-6ac01e00-f98a-11ea-9aa8-ae562dd34004.png)

#### Chrome / Edge

##### Error No short code

![image](https://user-images.githubusercontent.com/1135464/93569858-1026c200-f98a-11ea-9b55-efe37843e05e.png)

##### Error No Region

![image](https://user-images.githubusercontent.com/1135464/93569890-1cab1a80-f98a-11ea-8e19-53b02ca5b530.png)

##### Success 

![image](https://user-images.githubusercontent.com/1135464/93569998-406e6080-f98a-11ea-96b8-0df5da680027.png)


### Screencast

https://drive.google.com/file/d/1CdByL2MOs0k4UOoVf6qUdXEmBIY9vOQJ/view


### Tested

- [x] Chrome
- [x] Firefox
- [x] MS Edge